### PR TITLE
Link URLs in preview (`featureHtml`)

### DIFF
--- a/assets/preview-table.html
+++ b/assets/preview-table.html
@@ -139,7 +139,11 @@
         var sortedPropertyKeys = Object.keys(f.properties).sort((a,b) => a.localeCompare(b))
         var h = "<p>";
         sortedPropertyKeys.forEach(k => {
-          h += "<b>" + k + ":</b> " + f.properties[k] + "<br/>"
+          var v = f.properties[k];
+          if(v.toString().startsWith('http')) {
+            v = `<a target="_blank" href="${v}">${v}</a>`
+          }
+          h += "<b>" + k + ":</b> " + v + "<br/>"
         })
         h += "</p>";
         return h


### PR DESCRIPTION
This is based on https://github.com/CrunchyData/pg_tileserv/pull/157 but a separate PR so they may be merged independently (in the right order … or after changing the base … or rebase).

---

Adds simplistic URL check and link. **Allows for easier debugging with custom debugging URLs** but also original OSM URLs inside of tag-values like `website`. I left out the recommended `noreferrer noopener …` since this is just a debugging preview.

Example:
```js
var input = { properties: {
  "x": 2, 
  "a": 1, 
  "osm_url": "http://www.osm.org/way/123", 
  "website": "https://example.com"
} };
featureHtml(input);
```
```html
<p>
  <b>a:</b> 1<br/>
  <b>osm_url:</b> <a target="_blank" href="http://www.osm.org/way/123">http://www.osm.org/way/123</a><br/>
  <b>website:</b> <a target="_blank" href="https://example.com">https://example.com</a><br/>
  <b>x:</b> 2<br/>
</p>
```